### PR TITLE
Removed faulty > sign in image display template

### DIFF
--- a/regenwolken/templates/image.html
+++ b/regenwolken/templates/image.html
@@ -9,6 +9,6 @@
 </header>
 
 <section id="content">
-  <img alt="{{ drop.name | safe }}" src="{{ drop.content_url }}>">
+  <img alt="{{ drop.name | safe }}" src="{{ drop.content_url }}">
 </section>
 {% endblock %}


### PR DESCRIPTION
The file regenwolken/templates/image.html contained a > character at the end of the image destination field.
Whilst in practice, the web server (or the python implementation?) just drops the > sign and everything works fine, I recommend fixing this in the template. ;)
